### PR TITLE
Add undefined check to StackUtils.build

### DIFF
--- a/modules/StackUtils.js
+++ b/modules/StackUtils.js
@@ -26,7 +26,7 @@ export const build = <Item>(
       } else if (key === 'render' || key === 'component' || key === 'children') {
         return {
           ...props,
-          [key]: oldBuild
+          [key]: oldBuild && oldBuild[index]
             ? oldBuild[index][key]
             : () => React.cloneElement(child),
         }


### PR DESCRIPTION
`oldBuild[index][key]` can cause `Cannot read property 'render' of undefined` exceptions when the `index` is bigger than `oldBuild.length`. This PR adds another check to prevent such errors.