### PR TITLE
Mode configuration

### DIFF
--- a/docs/NAVIGATION.md
+++ b/docs/NAVIGATION.md
@@ -48,6 +48,7 @@ const App = () => (
 * **onTransitionEnd** `?Function` function invoked once the card transition animation completes
 * **cardStyle** `?StyleSheet` override style for the card component
 * **configureTransition** `?Function` function which customize animation
+* **mode** `?string` sets the mode configuration. Can be either `card` (default) or `modal`
 
 #### `<Card />` props
 

--- a/packages/react-router-navigation/src/DefaultRenderer.js
+++ b/packages/react-router-navigation/src/DefaultRenderer.js
@@ -137,7 +137,7 @@ class DefaultRenderer extends React.Component<Props> {
       <CardStack
         {...transitionProps}
         scenes={scenes}
-        mode="card"
+        mode={this.props.mode ? this.props.mode : 'card'}
         headerMode={Platform.OS === 'ios' ? 'float' : 'screen'}
         navigationState={this.props.navigationState}
         router={this.getRouter({ ...transitionProps, scenes })}

--- a/packages/react-router-navigation/src/DefaultRenderer.js
+++ b/packages/react-router-navigation/src/DefaultRenderer.js
@@ -137,7 +137,7 @@ class DefaultRenderer extends React.Component<Props> {
       <CardStack
         {...transitionProps}
         scenes={scenes}
-        mode={this.props.mode ? this.props.mode : 'card'}
+        mode={this.props.mode || 'card'}
         headerMode={Platform.OS === 'ios' ? 'float' : 'screen'}
         navigationState={this.props.navigationState}
         router={this.getRouter({ ...transitionProps, scenes })}

--- a/packages/react-router-navigation/src/TypeDefinitions.js
+++ b/packages/react-router-navigation/src/TypeDefinitions.js
@@ -45,6 +45,7 @@ export type NavigationProps = NavBarProps & {
   ) => NavigationTransitionSpec,
   onTransitionStart?: (...args: Array<mixed>) => void,
   onTransitionEnd?: (...args: Array<mixed>) => void,
+  mode?: string,
 }
 
 export type Card = CardProps & { key: string }

--- a/packages/react-router-navigation/src/TypeDefinitions.js
+++ b/packages/react-router-navigation/src/TypeDefinitions.js
@@ -45,7 +45,7 @@ export type NavigationProps = NavBarProps & {
   ) => NavigationTransitionSpec,
   onTransitionStart?: (...args: Array<mixed>) => void,
   onTransitionEnd?: (...args: Array<mixed>) => void,
-  mode?: string,
+  mode?: 'card' | 'modal',
 }
 
 export type Card = CardProps & { key: string }


### PR DESCRIPTION
Hey @LeoLeBras!

Thank you for your work, I really appreciate it 👍 

I needed to set the mode configuration to `modal` so I made this small change.

> The mode configuration for StackNavigator can be either card (default) or modal. The modal behavior slides the screen in the from the bottom on iOS and allows the user to scope down from the top to dismiss it. The modal configuration has no effect on Android because full-screen modals don't have any different transition behavior on the platform.
[https://reactnavigation.org/docs/modal.html](url)

Let me know if I can help. I live in Paris, so we can meet and talk about the future of this project if you want.

Thanks again!