### PR TITLE
Allow for going back multiple screens in nested Navigation

### DIFF
--- a/packages/react-router-navigation-core/src/CardStack.js
+++ b/packages/react-router-navigation-core/src/CardStack.js
@@ -152,7 +152,7 @@ class CardStack extends React.Component<Props, State> {
                   // eslint-disable-next-line
                   n > state.navigationState.index ? 1 : state.navigationState.index - n + 1,
                 ),
-                state.navigationState.index - n,
+                n > state.navigationState.index ? 0 : state.navigationState.index - n,
               ),
             }))
           } else {

--- a/packages/react-router-navigation-core/src/CardStack.js
+++ b/packages/react-router-navigation-core/src/CardStack.js
@@ -150,7 +150,7 @@ class CardStack extends React.Component<Props, State> {
                 state.navigationState.routes.slice(
                   0,
                   // eslint-disable-next-line
-                  state.navigationState.index - n + 1,
+                  n > state.navigationState.index ? 1 : state.navigationState.index - n + 1,
                 ),
                 state.navigationState.index - n,
               ),


### PR DESCRIPTION
Nested `Navigation` elements work for the most part, except when trying to go back more than 1 screen in history across those nested `CardStack`s. The parent `CardStack` isn't necessarily aware of all the current cards in history (and therefore the "real" `navigationState.index`), so it ends up passing an empty array for routes and a negative index to `StateUtils.reset()` which throws an error.

This fixes that issue by defaulting to 1 route and 0 index if n is greater than the `navigationState.index`.